### PR TITLE
Missing $query variable in getSignature() call in _post method()

### DIFF
--- a/library/eden/twitter/base.php
+++ b/library/eden/twitter/base.php
@@ -113,7 +113,7 @@ class Eden_Twitter_Base extends Eden_Oauth_Base {
 			->setSignatureToHmacSha1();
 		
 		//get the authorization parameters as an array
-		$signature 		= $rest->getSignature();
+		$signature 		= $rest->getSignature($query);
 		$authorization 	= $rest->getAuthorization($signature, false);
 		$authorization 	= $this->_buildQuery($authorization);
 		


### PR DESCRIPTION
Signed-off-by: Nikko Bautista nikko@nikkobautista.com
