### PR TITLE
$message constructor parameter is ignored

### DIFF
--- a/library/eden/facebook/post.php
+++ b/library/eden/facebook/post.php
@@ -38,7 +38,7 @@ class Eden_Facebook_Post extends Eden_Class {
 			->argument(2, 'string');	
 			
 		$this->_token 	= $token;
-		$this->_message = $message;
+		$this->_post['message'] = $message;
 	}
 	
 	/* Public Methods


### PR DESCRIPTION
$message constructor parameter should be injected to $_post protected array.
