### PR TITLE
Eden_Mail_Imap::remove gets array from move, but checks for int or string

### DIFF
--- a/library/eden/mail/imap.php
+++ b/library/eden/mail/imap.php
@@ -356,7 +356,7 @@ class Eden_Mail_Imap extends Eden_Class {
 	 * @return this
 	 */
 	public function remove($uid) {
-		Eden_Mail_Error::i()->argument(1, 'int', 'string');
+		Eden_Mail_Error::i()->argument(1, 'int', 'string', 'array');
 		
 		if(!$this->_socket) {
 			$this->connect();


### PR DESCRIPTION
Had a problem when i moved mails, because the uid becomes an array in move, and is then a parameter for remove, which tests for int or string,

Signed-off-by: Guenter Weber webersheim@gmail.com
