### PR TITLE
Fix parse error in ZenDesk Groups Class

### DIFF
--- a/library/eden/zendesk/groups.php
+++ b/library/eden/zendesk/groups.php
@@ -116,7 +116,7 @@ class Eden_ZenDesk_Groups extends Eden_ZenDesk_Base {
 		$this->_query['group']['name'] = $name;
 		
 		return $this;
-	}1
+	}
 	
 	/* Protected Methods
 	-------------------------------*/


### PR DESCRIPTION
Fix parse error in ZenDesk Groups Class
